### PR TITLE
Ensure task starts if laptop is running on battery

### DIFF
--- a/en-SyncthingLogonTask.js
+++ b/en-SyncthingLogonTask.js
@@ -112,6 +112,7 @@ function createOrUpdateLogonTask(taskName,programName,programArgs) {
   execAction.Path = programName;
   execAction.Arguments = programArgs;
   taskDefinition.Principal.LogonType = TASK_LOGON_INTERACTIVE_TOKEN;
+  taskDefinition.Settings.DisallowStartIfOnBatteries = false;
   var trigger = taskDefinition.Triggers.Create(TASK_TRIGGER_LOGON);
   trigger.UserId = WshNetwork.UserDomain + "\\" + WshNetwork.UserName;
   try {


### PR DESCRIPTION
By default Task Scheduler tasks created though the COM API have the "Start the task only if the computer is on AC Power" checked.