### PR TITLE
Handle the name of the "port probing" flag

### DIFF
--- a/en-SetSyncthingConfig.js
+++ b/en-SetSyncthingConfig.js
@@ -78,7 +78,7 @@ function main() {
       }
       return ERROR_FILE_NOT_FOUND;
     }
-    var cmdLine = '"' + syncthingPath + '" generate --skip-port-probing --home="' + configPath + '"';
+    var cmdLine = '"' + syncthingPath + '" generate --no-port-probing --home="' + configPath + '"';
     if ( ! defaultFolder ) {
       cmdLine += ' --no-default-folder';
     }


### PR DESCRIPTION
In Syncthing v2, the `--skip-port-probing` flag was renamed to `--no-port-probing`.
This results in an error if we want to generate a config for a new install.

Since Syncthing Windows Setup accepts a syncthing binary from a zip file, we can't know which version it is, and this PR is an attempt at detecting the version (by looking at the version info in the exe) and selecting the proper name of the flag.